### PR TITLE
add docgen skill for AgentCore document generation

### DIFF
--- a/skills/docgen/LICENSE.txt
+++ b/skills/docgen/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 tsaol
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/docgen/SKILL.md
+++ b/skills/docgen/SKILL.md
@@ -1,0 +1,271 @@
+---
+name: docgen
+description: >
+  Generate documents (PPTX, DOCX, PDF, XLSX, HTML) via AWS Bedrock AgentCore Runtime.
+  Use this skill when the user asks to:
+  - Generate a PPT/presentation / 生成PPT
+  - Generate a Word document / 生成Word文档
+  - Generate a PDF / 生成PDF
+  - Generate an Excel spreadsheet / 生成Excel表格
+  - Generate a frontend HTML page / 生成前端页面
+  - Convert an article to a presentation / 把文章转成PPT
+  - Create a document from a topic / 根据话题生成文档
+  This skill uses AWS Bedrock AgentCore Runtime (cloud-based, Claude + Code Interpreter).
+license: MIT
+---
+
+# Document Generation via AgentCore Runtime
+
+## Overview
+
+This skill generates professional documents by calling an **AWS Bedrock AgentCore Runtime** agent. The remote agent uses Claude + Code Interpreter to produce high-quality files — no local office software required.
+
+## Supported Document Types
+
+| Type | Flag | Output | Use Case |
+|------|------|--------|----------|
+| pptx | `--type pptx` | PowerPoint | Presentations, tech talks |
+| docx | `--type docx` | Word | Reports, design docs |
+| pdf | `--type pdf` | PDF | Invoices, formal documents |
+| xlsx | `--type xlsx` | Excel | Data tables, KPI tracking |
+| frontend-design | `--type frontend-design` | HTML | Dashboards, landing pages |
+
+## Prerequisites
+
+1. **AWS credentials** configured (`~/.aws/credentials`, env vars, or IAM role)
+2. **AgentCore Runtime** deployed with document generation agent
+3. **Python 3.10+** with `boto3` installed
+
+### Required IAM Permissions
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "bedrock-agentcore:InvokeAgentRuntime",
+      "Resource": "<your-runtime-arn>"
+    }
+  ]
+}
+```
+
+### Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `RUNTIME_ARN` | Yes | AgentCore Runtime ARN |
+| `AWS_REGION` | No | AWS region (default: `ap-northeast-1`) |
+
+The script also auto-loads `.env` from `~/codes/document-generation-mcp/.env` if present.
+
+## Quick Start
+
+```bash
+# Generate a PowerPoint
+python scripts/docgen.py --type pptx \
+  --prompt "Create a 10-slide presentation about cloud computing" \
+  --output presentation.pptx
+
+# Generate a Word document
+python scripts/docgen.py --type docx \
+  --prompt "Write a technical design document about microservices" \
+  --output design.docx
+
+# Generate from a prompt file (for long prompts)
+python scripts/docgen.py --type pptx \
+  --prompt-file my-prompt.txt \
+  --output slides.pptx
+
+# Custom timeout for complex documents
+python scripts/docgen.py --type pptx \
+  --prompt-file complex-prompt.txt \
+  --output output.pptx \
+  --timeout 1800
+```
+
+## Python API
+
+```python
+from scripts.docgen import generate
+
+result = generate(
+    skill_type="pptx",
+    prompt="Create a 12-slide deck about AI trends in 2026",
+    output_path="output/ai-trends.pptx",
+)
+
+if result["success"]:
+    print(f"Saved: {result['path']} ({result['size']} bytes, {result['elapsed']:.0f}s)")
+else:
+    print(f"Error: {result['error']}")
+```
+
+## How Claude Code Should Use This Skill
+
+When a user asks to generate a document, follow this workflow:
+
+### Step 1: Determine the Mode
+
+- **Mode A (Article -> Document)**: User has an existing article/markdown and wants it converted
+- **Mode B (Topic -> Document)**: User provides a topic and wants a document from scratch
+
+### Step 2: Construct the Prompt
+
+The prompt quality determines the output quality. Follow these guidelines:
+
+#### PPTX Prompt Template
+
+```
+Create a [N]-slide professional presentation about [topic].
+Use [color scheme] with [text color] on [background color].
+
+IMPORTANT: Every slide MUST include speaker notes. Add speaker notes using
+the python-pptx notes_slide feature: slide.notes_slide.notes_text_frame.text = "notes content".
+Speaker notes should be 80-150 words per slide, written in conversational style,
+explaining the key talking points. Do NOT just repeat the bullet points.
+
+Slide 1: Title - [title], [subtitle]
+Slide 2: [Section] - [key point 1], [key point 2], [key point 3]
+Slide 3: [Section] - [data table or key facts]
+...
+Slide N: Thank You - [closing info]
+```
+
+**PPTX Rules**:
+- Each slide description should be under 50 words (keywords and data, not paragraphs)
+- Total slides should be <= 22 (more affects generation quality)
+- Use "table with N rows" for data tables
+- Always include speaker notes instructions
+- Specify color scheme explicitly
+
+#### DOCX Prompt Template
+
+```
+Create a professional [document type] about [topic].
+Include sections: [section list].
+Section 1: [Title] - [content points]
+...
+```
+
+#### XLSX Prompt Template
+
+```
+Create an Excel spreadsheet for [purpose].
+Sheet 1: [name] - columns: [col1], [col2], ...
+Sheet 2: [name] - [description]
+```
+
+### Step 3: Save the Prompt (Optional)
+
+For debugging and reuse, save the prompt to a file:
+
+```bash
+# Save to prompt file
+cat > prompt.txt << 'EOF'
+[your prompt here]
+EOF
+```
+
+### Step 4: Generate the Document
+
+```bash
+python <skill-path>/scripts/docgen.py \
+  --type pptx \
+  --prompt-file prompt.txt \
+  --output output/presentation.pptx
+```
+
+**Expected generation times**:
+- HTML: 30s - 1min
+- PPTX (<=10 slides): 2-5 min
+- PPTX (10-22 slides): 3-15 min
+- DOCX/PDF: 2-5 min
+- XLSX: 2-4 min
+
+Complex presentations (15+ slides with detailed content) can take 10-25 minutes.
+The default timeout is 1200s (20 min). Use `--timeout 1800` for very complex documents.
+
+### Step 5: Verify Output
+
+Check that the file was generated and report the result:
+```bash
+ls -la output/presentation.pptx
+```
+
+## Command Line Options
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--type` | | Document type: docx, pdf, pptx, xlsx, frontend-design (required) |
+| `--prompt` | | Document description (inline) |
+| `--prompt-file` | | Read prompt from file |
+| `--output` | `-o` | Output file path (required) |
+| `--region` | | AWS region (default: ap-northeast-1) |
+| `--runtime-arn` | | AgentCore Runtime ARN |
+| `--timeout` | | Read timeout in seconds (default: 1200) |
+
+## Tips for Better Results
+
+1. **Be specific about colors**: Always provide hex codes, not just color names
+2. **Keep slide content concise**: Keywords and data points, not full sentences
+3. **Speaker notes matter**: Include the speaker notes instruction for PPTX — it dramatically improves presentation quality
+4. **Chinese content**: Specify "All slide titles and content MUST be in Chinese" if needed
+5. **Data tables**: Describe as "table: col1, col2, col3" with row data
+6. **Complex prompts**: Save to a file with `--prompt-file` instead of inline `--prompt`
+
+## Troubleshooting
+
+### Timeout Errors
+
+For complex documents (15+ slides, detailed content), the server may need more than 20 minutes:
+
+```bash
+python scripts/docgen.py --type pptx --prompt-file prompt.txt --output out.pptx --timeout 1800
+```
+
+### RUNTIME_ARN Not Configured
+
+Set the environment variable or pass via CLI:
+
+```bash
+export RUNTIME_ARN="arn:aws:bedrock-agentcore:ap-northeast-1:123456789:runtime/your-agent-id"
+python scripts/docgen.py --type pptx --prompt "..." --output out.pptx
+```
+
+Or create a `.env` file at `~/codes/document-generation-mcp/.env`:
+
+```
+AWS_REGION=ap-northeast-1
+RUNTIME_ARN=arn:aws:bedrock-agentcore:ap-northeast-1:123456789:runtime/your-agent-id
+```
+
+### Empty or Failed Response
+
+The AgentCore agent may fail silently on overly complex prompts. Try:
+- Reducing the number of slides (keep <= 16)
+- Simplifying per-slide content
+- Splitting into multiple smaller documents
+
+## Architecture
+
+```
+User / Claude Code
+       |
+       | python scripts/docgen.py --type pptx --prompt "..."
+       |
+       v
+  boto3 invoke_agent_runtime()
+       |
+       v
+  AWS Bedrock AgentCore Runtime
+       |
+       | Strands Agent + Claude Opus 4.6 + Code Interpreter
+       |
+       v
+  Generated file (base64 encoded in response)
+       |
+       v
+  Decoded and saved to --output path
+```

--- a/skills/docgen/scripts/docgen.py
+++ b/skills/docgen/scripts/docgen.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+Document Generation via AWS Bedrock AgentCore Runtime.
+
+Generates pptx, docx, pdf, xlsx, or html files using a remote
+AgentCore Runtime agent (Claude + Code Interpreter).
+
+Usage:
+    python3 docgen.py --type pptx --prompt "Create a 10-slide deck about AI" --output slides.pptx
+    python3 docgen.py --type docx --prompt "Write a technical report" --output report.docx
+    python3 docgen.py --type pptx --prompt-file prompt.txt --output deck.pptx
+
+Environment variables:
+    AWS_REGION      - AWS region (default: ap-northeast-1)
+    RUNTIME_ARN     - AgentCore Runtime ARN (required)
+    AWS credentials - From ~/.aws/credentials, env vars, or IAM role
+
+Optionally reads .env from ~/codes/document-generation-mcp/.env if present.
+"""
+
+import argparse
+import base64
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+VALID_TYPES = {"docx", "pdf", "pptx", "xlsx", "frontend-design"}
+
+# Try loading .env from document-generation-mcp project (optional)
+for _env_candidate in [
+    Path.home() / "codes" / "document-generation-mcp" / ".env",
+    Path(__file__).resolve().parent.parent / ".env",
+]:
+    if _env_candidate.exists():
+        for line in _env_candidate.read_text().splitlines():
+            line = line.strip()
+            if line and not line.startswith("#") and "=" in line:
+                key, _, value = line.partition("=")
+                os.environ.setdefault(key.strip(), value.strip())
+        break
+
+DEFAULT_REGION = os.environ.get("AWS_REGION", "ap-northeast-1")
+DEFAULT_RUNTIME_ARN = os.environ.get("RUNTIME_ARN", "")
+
+
+def generate(skill_type, prompt, output_path, region=None, runtime_arn=None,
+             read_timeout=1200):
+    """Generate a document via AgentCore Runtime.
+
+    Args:
+        skill_type: One of docx, pdf, pptx, xlsx, frontend-design
+        prompt: Description of the document to create
+        output_path: Where to save the generated file
+        region: AWS region (default from env)
+        runtime_arn: AgentCore Runtime ARN (default from env)
+        read_timeout: HTTP read timeout in seconds (default 1200)
+
+    Returns:
+        dict with keys: success (bool), path (str), size (int), elapsed (float)
+    """
+    import boto3
+    from botocore.config import Config
+
+    region = region or DEFAULT_REGION
+    runtime_arn = runtime_arn or DEFAULT_RUNTIME_ARN
+
+    if not runtime_arn:
+        return {"success": False, "error": "RUNTIME_ARN not configured. Set via env var or --runtime-arn."}
+
+    if skill_type not in VALID_TYPES:
+        return {"success": False, "error": f"Invalid type: {skill_type}. Valid: {sorted(VALID_TYPES)}"}
+
+    client = boto3.client(
+        "bedrock-agentcore",
+        region_name=region,
+        config=Config(read_timeout=read_timeout, connect_timeout=30),
+    )
+
+    payload = json.dumps({
+        "skill_type": skill_type,
+        "prompt": prompt,
+        "filename": os.path.basename(output_path),
+    })
+
+    start = time.time()
+
+    try:
+        response = client.invoke_agent_runtime(
+            agentRuntimeArn=runtime_arn,
+            payload=payload,
+            contentType="application/json",
+            accept="application/json",
+        )
+
+        body = response.get("response")
+        if body is None:
+            return {"success": False, "error": "Empty response from AgentCore", "elapsed": time.time() - start}
+
+        data = body.read() if hasattr(body, "read") else body
+        if isinstance(data, bytes):
+            data = data.decode("utf-8")
+
+        result = json.loads(data)
+        elapsed = time.time() - start
+
+        if result.get("status") == "success" and "file_base64" in result:
+            file_bytes = base64.b64decode(result["file_base64"])
+            os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
+            with open(output_path, "wb") as f:
+                f.write(file_bytes)
+            return {
+                "success": True,
+                "path": output_path,
+                "size": len(file_bytes),
+                "elapsed": elapsed,
+            }
+        else:
+            return {
+                "success": False,
+                "error": result.get("error", "No file in response"),
+                "elapsed": elapsed,
+            }
+
+    except Exception as e:
+        return {"success": False, "error": str(e), "elapsed": time.time() - start}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate documents via AgentCore Runtime")
+    parser.add_argument("--type", dest="skill_type", choices=sorted(VALID_TYPES), required=True,
+                        help="Document type to generate")
+    parser.add_argument("--prompt", help="Document description")
+    parser.add_argument("--prompt-file", help="Read prompt from file")
+    parser.add_argument("--output", "-o", required=True, help="Output file path")
+    parser.add_argument("--region", default=DEFAULT_REGION, help=f"AWS region (default: {DEFAULT_REGION})")
+    parser.add_argument("--runtime-arn", default=DEFAULT_RUNTIME_ARN, help="AgentCore Runtime ARN")
+    parser.add_argument("--timeout", type=int, default=1200, help="Read timeout in seconds (default: 1200)")
+
+    args = parser.parse_args()
+
+    if args.prompt_file:
+        prompt = Path(args.prompt_file).read_text().strip()
+    elif args.prompt:
+        prompt = args.prompt
+    else:
+        print("Error: --prompt or --prompt-file required", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Generating {args.skill_type} \u2192 {args.output}")
+    print(f"Prompt length: {len(prompt)} chars")
+
+    result = generate(
+        skill_type=args.skill_type,
+        prompt=prompt,
+        output_path=args.output,
+        region=args.region,
+        runtime_arn=args.runtime_arn,
+        read_timeout=args.timeout,
+    )
+
+    if result["success"]:
+        size_kb = result["size"] / 1024
+        mins, secs = divmod(int(result["elapsed"]), 60)
+        print(f"Saved: {result['path']} ({size_kb:.1f} KB) in {mins}m {secs}s")
+    else:
+        print(f"Failed: {result['error']}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `docgen` skill that generates documents (PPTX, DOCX, PDF, XLSX, HTML) via AWS Bedrock AgentCore Runtime
- Includes `scripts/docgen.py` with CLI and Python API, configurable timeout (default 1200s)
- SKILL.md with prompt templates, troubleshooting guide, and architecture overview

## Test plan
- [x] Script tested on EC2 generating 14-slide and 16-slide PPTX successfully
- [x] Skill registered in `~/.claude/skills/docgen` and visible in Claude Code skill list
- [ ] Verify `/docgen` trigger works in a new Claude Code session