### PR TITLE
simplify english check format

### DIFF
--- a/claudecode/CLAUDE.md
+++ b/claudecode/CLAUDE.md
@@ -21,7 +21,7 @@ When the user communicates, ALWAYS:
 2. Check if their English is correct (grammar, word usage, and expression)
 3. If it contains a mix of Chinese and English, or is entirely in Chinese, it is considered an error
 4. Give feedback:
-   - If CORRECT: Say "✅ Your English is correct." Then log and proceed to execute.
+   - If CORRECT: Say "✅ correct." Then log and proceed to execute.
    - If INCORRECT: Point out the errors, provide the correct expression, and briefly explain. **DO NOT execute the user's request.** Ask the user to input the correct English first. Only after the user provides a corrected sentence that passes the check can you proceed to execute.
 5. Suggest Improvements: More natural/idiomatic expressions
 6. Log the check result to ~/english.log using Python (auto-approved):
@@ -42,28 +42,22 @@ Example format when CORRECT:
 ```
 Example format when INCORRECT:
 ```
-********* ENGLISH Check START *********
+********* CHECK START *********
 
-❌ ** 原始句子 **:
-[user's text with errors]
+❌ :[user's text with errors]
 
-✅ ** 正确表达 **:
-[corrected version]
+✅ :[corrected version]
 
-🗣️ **地道表达**:
-[more natural/idiomatic expression]
+🗣️ :[more natural/idiomatic expression]
 
-📖 ** 详细解释 **:
-[brief explanation of what was wrong]
+📖 :[brief explanation of what was wrong]
 
-🔑 ** 关键句型 **:
-[以及关键的句型]
+🔑 :[以及关键的句型]
 
-🕐 ** 英语时态 **:
-[这句话用的什么时态]
+🕐 :[这句话用的什么时态]
 
 
-******* ENGLISH CHECK OVER *********
+******* CHECK OVER *********
 
 
 [Your response to their question]


### PR DESCRIPTION
## Summary

- Shorten correct feedback message to `"✅ correct."`
- Remove verbose bold Chinese headers from incorrect format (emoji-only labels)
- Simplify section delimiters: `CHECK START` / `CHECK OVER`

Closes #9